### PR TITLE
fix(CacheableQueryBuilder): remove expired items from tagged cache

### DIFF
--- a/src/Database/Query/CacheableQueryBuilder.php
+++ b/src/Database/Query/CacheableQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace ElipZis\Cacheable\Database\Query;
 
+use Illuminate\Cache\RedisTaggedCache;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
@@ -137,10 +138,10 @@ class CacheableQueryBuilder extends Builder
         $modelClasses = $this->getIdentifiableModelClasses($this->getIdentifiableValue());
 
         // clear expired cached queries in tagged cache
-        if ($isTaggableStore) {
+        if ($isTaggableStore && Cache::tags($modelClasses) instanceof RedisTaggedCache) {
             Cache::tags($modelClasses)->flushStale();
         }
-        
+
         //If cached, return
         if (($isTaggableStore && Cache::tags($modelClasses)->has($cacheKey)) || Cache::has($cacheKey)) {
             $this->log("Found cache entry for '{$cacheKey}'");

--- a/src/Database/Query/CacheableQueryBuilder.php
+++ b/src/Database/Query/CacheableQueryBuilder.php
@@ -136,6 +136,11 @@ class CacheableQueryBuilder extends Builder
         //and create additional identifiers
         $modelClasses = $this->getIdentifiableModelClasses($this->getIdentifiableValue());
 
+        // clear expired cached queries in tagged cache
+        if ($isTaggableStore) {
+            Cache::tags($modelClasses)->flushStale();
+        }
+        
         //If cached, return
         if (($isTaggableStore && Cache::tags($modelClasses)->has($cacheKey)) || Cache::has($cacheKey)) {
             $this->log("Found cache entry for '{$cacheKey}'");


### PR DESCRIPTION
This fix addresses a Redis behavior where expired items in sorted sets are not automatically removed. By calling flushStale() before cache operations, we ensure expired items are cleared, maintaining cache accuracy and preventing stale data issues.