### PR TITLE
Handle Undefined array key "values" when using whereNull

### DIFF
--- a/src/Database/Query/CacheableQueryBuilder.php
+++ b/src/Database/Query/CacheableQueryBuilder.php
@@ -212,7 +212,7 @@ class CacheableQueryBuilder extends Builder
                 return $this->getIdentifiableValue($where['query']->wheres);
             }
             if (isset($where['column']) && $where['column'] === $this->modelIdentifier) {
-                return $where['value'] ?? $where['values'];
+                return $where['value'] ?? $where['values'] ?? null;
             }
         }
 


### PR DESCRIPTION
Sometimes both "value" and "values" do not exist.

```php
$user = \App\Models\User::query()
    ->where('id', null) // The null here is just to reproduce the problem
    ->first();
```

> $wheres [{"type":"Null","column":"id","boolean":"and"}] 